### PR TITLE
Fix help prompt

### DIFF
--- a/notes/notes.py
+++ b/notes/notes.py
@@ -20,7 +20,6 @@ def get_symbols():
     # we need to use a constant value for the ``terminal_width`` since Click's `help` window set's constraints
     # on the width used for the help prompt and the symbols would overflow if the window gets wider
     terminal_width = 36
-    print(terminal_width)
     return "".join(["=" for pix in range(terminal_width)])
 
 

--- a/notes/notes.py
+++ b/notes/notes.py
@@ -27,7 +27,7 @@ def display_intro():
     cli_name = click.style("Terminal Notes ~ Saakshaat", fg='blue')
     cli_bars = click.style(get_symbols(), fg='green')
     cli_description = click.style(f"""
-        {"Take notes directly from your terminal."}
+       {"Take notes directly from your terminal."}
 
         {"Notes CLI allows you to save notes locally in a SQLite database which is cached to a memory threshold of 50 notes."}
 

--- a/notes/notes.py
+++ b/notes/notes.py
@@ -17,23 +17,31 @@ def get_centered_text(text: str):
 
 
 def get_symbols():
-    terminal_width = int(click.termui.get_terminal_size()[0])
-    return "".join(["=" for i in range(terminal_width)])
+    # we need to use a constant value for the ``terminal_width`` since Click's `help` window set's constraints
+    # on the width used for the help prompt and the symbols would overflow if the window gets wider
+    terminal_width = 36
+    print(terminal_width)
+    return "".join(["=" for pix in range(terminal_width)])
 
 
 def display_intro():
-    click.secho(f"""
-        Terminal Notes ~ Saakshaat
-    """, fg='blue')
-    click.secho(get_symbols(), fg='green')
-    click.secho(f"""
-        {get_centered_text("Take notes directly from your terminal.")}
-        {get_centered_text("Notes CLI allows you to save notes locally in a SQLite database which is cached to a memory threshold of 50 notes.")}
-        {get_centered_text("With Notes CLI, you can save your ToDos, meeting notes and much more conveniently and quickly.")}
-                """, fg='red')
-    click.secho(get_symbols(), fg='green')
+    cli_name = click.style("Terminal Notes ~ Saakshaat", fg='blue')
+    cli_bars = click.style(get_symbols(), fg='green')
+    cli_description = click.style(f"""
+        {"Take notes directly from your terminal."}
 
-    return None
+        {"Notes CLI allows you to save notes locally in a SQLite database which is cached to a memory threshold of 50 notes."}
+
+        {"With Notes CLI, you can save your ToDos, meeting notes and much more conveniently and quickly."}""",
+                                  fg='red')
+
+    full_intro = f"""{cli_name}\n
+{cli_bars}\n
+{cli_description}\n
+{cli_bars}\n
+    """
+
+    return full_intro
 
 
 def get_all_profiles():
@@ -48,6 +56,7 @@ def get_all_profiles():
 @click.group(help=display_intro())
 @click.pass_context
 def cli(ctx):
+    click.style("", fg='white')
     ctx.ensure_object(dict)
 
     conn, cur = create_connection()


### PR DESCRIPTION
The main 'cli' command group's help prompt echoed the intro text everytime any command ran. The reason for that was it used the `display_intro` function which, instead of returning a string to echo, echoed strings itself.

So we fixed that by returning styled strings.

Since the `help` message is constrained to a certain width, depending on the terminal window size led to overflows, so we had to fix the width of any elements depending on that.

![Screen Shot 2020-12-28 at 10 57 27 AM](https://user-images.githubusercontent.com/49038287/103191570-7b721f80-48fb-11eb-87d1-3a8d7e9be652.png)

![Screen Shot 2020-12-28 at 10 57 45 AM](https://user-images.githubusercontent.com/49038287/103191578-862cb480-48fb-11eb-918b-7d4a445ded4e.png)
