### PR TITLE
Threshold

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,0 @@
-from notes import cli
-
-if __name__ == '__main__':
-    cli(obj={})

--- a/notes/notes.py
+++ b/notes/notes.py
@@ -100,7 +100,7 @@ def reorganize_memory(conn):
     count = int(query.fetchone()[0])
 
     if count >= 25:
-        click.secho(f"Memory Full. Deleted: \n{conn.execute('SELECT created_at, content FROM notes;').fetchone()[1]}",
+        click.secho(f"Memory Full. Deleted note: \n{conn.execute('SELECT created_at, content FROM notes;').fetchone()[1]}",
                     fg='green')
         conn.execute("DELETE FROM notes WHERE id = (SELECT MIN(id) FROM notes);")
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='notes',
-    version='0.1',
+    version='1.0.0',
     py_modules=['notes'],
     install_requires=[
         'Click',


### PR DESCRIPTION
With this PR, we add a memory threshold on the total number of notes in memory at any given point of time. Currently, we've set this to 25 but in the future, we'll open this upto for the user to define when installing the CLI.

While adding a new note if the total number of notes is at or beyond the threshold, the earliest note gets deleted before adding the new ntoe.